### PR TITLE
Create a Kubernetes cluster and get your kubeconfig at the end

### DIFF
--- a/advanced/kubernetes-with-kubeconfig/main.tf
+++ b/advanced/kubernetes-with-kubeconfig/main.tf
@@ -1,0 +1,52 @@
+# Criando um cluster com um nodepool
+resource "mgc_kubernetes_cluster" "cluster_with_nodepool" {
+  name                 = var.cluster_name
+  enabled_bastion      = false
+  version              = var.kubernetes_version
+  enabled_server_group = false
+  description          = var.cluster_description
+  node_pools = [{
+    name     = var.nodepool_name
+    replicas = var.nodepool_replicas
+    flavor   = var.nodepool_flavor
+  }]
+}
+
+# Tempo de espera para o cluster ficar ativo
+# Ajuste o tempo conforme necessário
+resource "time_sleep" "wait_15_minutes" {
+  depends_on      = [mgc_kubernetes_cluster.cluster_with_nodepool]
+  create_duration = var.timer_duration
+}
+
+# Criando um nodepool
+resource "mgc_kubernetes_nodepool" "gp1_small" {
+  depends_on = [time_sleep.wait_15_minutes] # Wait timer
+  name       = "apis-2cpu-4gb-20gb"
+  cluster_id = mgc_kubernetes_cluster.cluster_with_nodepool.id
+  flavor     = var.nodepool_flavor
+  replicas   = var.nodepool_replicas
+  auto_scale = {
+    min_replicas = 1
+    max_replicas = 3
+  }
+}
+
+# Timer para esperar o cluster ficar ativo
+resource "time_sleep" "wait_for_cluster" {
+  depends_on      = [mgc_kubernetes_cluster.cluster_with_nodepool]
+  create_duration = "10m" # Ajuste o tempo conforme necessário
+}
+
+# Pegar o kubeconfig do cluster usando o output do cluster_id
+data "mgc_kubernetes_cluster_kubeconfig" "cluster" {
+  depends_on = [time_sleep.wait_for_cluster]
+  cluster_id = mgc_kubernetes_cluster.cluster_with_nodepool.id
+}
+
+# Salvar o kubeconfig em um arquivo local
+resource "local_file" "kubeconfig" {
+  provider = local
+  content  = data.mgc_kubernetes_cluster_kubeconfig.cluster.kubeconfig
+  filename = "${path.module}/kubeconfig.yaml"
+}

--- a/advanced/kubernetes-with-kubeconfig/outputs.tf
+++ b/advanced/kubernetes-with-kubeconfig/outputs.tf
@@ -1,0 +1,6 @@
+output "cluster_name" {
+  value = mgc_kubernetes_cluster.cluster_with_nodepool.name
+}
+output "cluster_id" {
+  value = mgc_kubernetes_cluster.cluster_with_nodepool.id
+}

--- a/advanced/kubernetes-with-kubeconfig/variables.tf
+++ b/advanced/kubernetes-with-kubeconfig/variables.tf
@@ -1,0 +1,41 @@
+variable "cluster_name" {
+  description = "Cluster name"
+  type        = string
+  default     = "mgc-cluster"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version"
+  type        = string
+  default     = "v1.28.5"
+}
+
+variable "cluster_description" {
+  description = "Cluster description"
+  type        = string
+  default     = "A Kubernetes cluster managed by Magalu Cloud."
+}
+
+variable "nodepool_name" {
+  description = "Nodepool name"
+  type        = string
+  default     = "mgc-nodepool"
+}
+
+variable "nodepool_replicas" {
+  description = "Number of nodepool replicas"
+  type        = number
+  default     = 1
+}
+
+variable "nodepool_flavor" {
+  description = "Nodepool flavor"
+  type        = string
+  default     = "cloud-k8s.gp1.small"
+}
+
+variable "timer_duration" {
+  description = "Timer duration"
+  type        = string
+  default     = "15m"
+}

--- a/advanced/kubernetes-with-kubeconfig/versions.tf
+++ b/advanced/kubernetes-with-kubeconfig/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    mgc = {
+      source = "magalucloud/mgc"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.5.1"
+    }
+  }
+}


### PR DESCRIPTION
This Pull Request includes functionalities to wait for the cluster creation, obtain the kubeconfig, and save it to a local file.

## Features

**1. Obtain Kubeconfig:**

- Uses a data source to get the kubeconfig for the Kubernetes cluster after creation.

**2. Save Kubeconfig:**

- Saves the obtained kubeconfig to a local file (kubeconfig.yaml).

After successful execution, check that the file `kubeconfig.yaml` has been created in the specified directory.


## `main.tf` File Structure
```
resource "time_sleep" "wait_for_cluster" {
  depends_on      = [mgc_kubernetes_cluster.cluster_with_nodepool]
  create_duration = "10m" # Adjust the time as necessary
}

data "mgc_kubernetes_cluster_kubeconfig" "cluster" {
  depends_on = [time_sleep.wait_for_cluster]
  cluster_id = mgc_kubernetes_cluster.cluster_with_nodepool.id
}

resource "local_file" "kubeconfig" {
  provider = local
  content  = data.mgc_kubernetes_cluster_kubeconfig.cluster.kubeconfig
  filename = "${path.module}/kubeconfig.yaml"
}
```