### PR TITLE
docs: use fully qualified provider source

### DIFF
--- a/advanced/attach-vm-block-storage/main.tf
+++ b/advanced/attach-vm-block-storage/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }

--- a/advanced/kubernetes-with-kubeconfig/versions.tf
+++ b/advanced/kubernetes-with-kubeconfig/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
     local = {
       source  = "hashicorp/local"

--- a/simple/api-key-with-vars/versions.tf
+++ b/simple/api-key-with-vars/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
       version = "0.23.0"
     }
     local = {

--- a/simple/api-key/README.md
+++ b/simple/api-key/README.md
@@ -20,7 +20,7 @@ Here is an example configuration:
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }

--- a/simple/api-key/main.tf
+++ b/simple/api-key/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }

--- a/simple/block-storage/attach/attach.tf
+++ b/simple/block-storage/attach/attach.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }

--- a/simple/block-storage/snapshots/snapshot.tf
+++ b/simple/block-storage/snapshots/snapshot.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }

--- a/simple/block-storage/volumes/volume.tf
+++ b/simple/block-storage/volumes/volume.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }

--- a/simple/dbaas/main.tf
+++ b/simple/dbaas/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }

--- a/simple/kubernetes/main.tf
+++ b/simple/kubernetes/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }

--- a/simple/object-storage/main.tf
+++ b/simple/object-storage/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }

--- a/simple/tf-state-s3-save/README.md
+++ b/simple/tf-state-s3-save/README.md
@@ -26,7 +26,7 @@ This guide explains how to configure Terraform to use the S3 backend for storing
    terraform {
      required_providers {
        mgc = {
-         source = "magalucloud/mgc"
+         source = "registry.terraform.io/magalucloud/mgc"
        }
      }
      backend "s3" {

--- a/simple/tf-state-s3-save/main.tf
+++ b/simple/tf-state-s3-save/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
   backend "s3" {

--- a/simple/virtual-machines/main.tf
+++ b/simple/virtual-machines/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mgc = {
-      source = "magalucloud/mgc"
+      source = "registry.terraform.io/magalucloud/mgc"
     }
   }
 }


### PR DESCRIPTION
Hi! Here's a fix for a minor issue I came across while trying the provider out with opentofu.

As the provider is not present in the OpenTofu registry, it's not usable by default as simply `magalucloud/mgc`. The error message provided by OpenTofu is not very useful nor very googleable by people not familiar with terraform terminology.

By fully qualifying the source (i.e. by including `registry.terraform.io`), the examples can be safely used by both OpenTofu and Terraform.